### PR TITLE
fix imdecode conversion

### DIFF
--- a/src/cv_compat.rs
+++ b/src/cv_compat.rs
@@ -26,9 +26,7 @@ pub mod imdecode {
         match flags {
             ImreadFlags::ImreadGrayscale => {
                 let gray_img = img.to_luma8();
-                let (width, height) = gray_img.dimensions();
-                Array3::from_shape_vec((height as usize, width as usize, 1), gray_img.into_raw())
-                    .map_err(|e| anyhow::anyhow!("Failed to reshape grayscale image: {}", e))
+                luma8_to_rgb_ndarray(gray_img)
             }
             ImreadFlags::ImreadColor => {
                 let rgb_img = img.to_rgb8();
@@ -71,6 +69,19 @@ pub mod imdecode {
             }
             channels => anyhow::bail!("Unsupported decoded image channel count: {}", channels),
         }
+    }
+
+    fn luma8_to_rgb_ndarray(gray_img: image::GrayImage) -> Result<Array3<u8>> {
+        let (width, height) = gray_img.dimensions();
+        let gray_raw = gray_img.into_raw();
+        let mut rgb_data = Vec::with_capacity(gray_raw.len() * 3);
+
+        for gray in gray_raw {
+            rgb_data.extend_from_slice(&[gray, gray, gray]);
+        }
+
+        Array3::from_shape_vec((height as usize, width as usize, 3), rgb_data)
+            .map_err(|e| anyhow::anyhow!("Failed to reshape grayscale image: {}", e))
     }
 }
 

--- a/src/cv_compat.rs
+++ b/src/cv_compat.rs
@@ -4,8 +4,7 @@ use ndarray::{Array3, ArrayView3};
 /// OpenCV-compatible image decoding functionality
 pub mod imdecode {
     use super::*;
-    use image::ImageFormat;
-    use std::io::Cursor;
+    use image::DynamicImage;
 
     /// Image read flags matching OpenCV constants
     #[derive(Debug, Clone, Copy)]
@@ -21,46 +20,56 @@ pub mod imdecode {
 
     /// Decode image from byte buffer (equivalent to cv2.imdecode)
     pub fn imdecode(buf: &[u8], flags: ImreadFlags) -> Result<Array3<u8>> {
-        let cursor = Cursor::new(buf);
-        let img = image::load(
-            cursor,
-            ImageFormat::from_extension("").unwrap_or(ImageFormat::Png),
-        )
-        .map_err(|e| anyhow::anyhow!("Failed to decode image: {}", e))?;
+        let img = image::load_from_memory(buf)
+            .map_err(|e| anyhow::anyhow!("Failed to decode image: {}", e))?;
 
         match flags {
             ImreadFlags::ImreadGrayscale => {
                 let gray_img = img.to_luma8();
                 let (width, height) = gray_img.dimensions();
-
-                // Convert to 3-channel grayscale (RGB format)
-                let mut rgb_data = Array3::<u8>::zeros((height as usize, width as usize, 3));
-                for y in 0..height {
-                    for x in 0..width {
-                        let pixel = gray_img.get_pixel(x, y);
-                        let gray_val = pixel[0];
-                        rgb_data[[y as usize, x as usize, 0]] = gray_val;
-                        rgb_data[[y as usize, x as usize, 1]] = gray_val;
-                        rgb_data[[y as usize, x as usize, 2]] = gray_val;
-                    }
-                }
-                Ok(rgb_data)
+                Array3::from_shape_vec((height as usize, width as usize, 1), gray_img.into_raw())
+                    .map_err(|e| anyhow::anyhow!("Failed to reshape grayscale image: {}", e))
             }
-            ImreadFlags::ImreadColor | ImreadFlags::ImreadUnchanged => {
+            ImreadFlags::ImreadColor => {
                 let rgb_img = img.to_rgb8();
                 let (width, height) = rgb_img.dimensions();
-
-                let mut rgb_data = Array3::<u8>::zeros((height as usize, width as usize, 3));
-                for y in 0..height {
-                    for x in 0..width {
-                        let pixel = rgb_img.get_pixel(x, y);
-                        rgb_data[[y as usize, x as usize, 0]] = pixel[0];
-                        rgb_data[[y as usize, x as usize, 1]] = pixel[1];
-                        rgb_data[[y as usize, x as usize, 2]] = pixel[2];
-                    }
-                }
-                Ok(rgb_data)
+                Array3::from_shape_vec((height as usize, width as usize, 3), rgb_img.into_raw())
+                    .map_err(|e| anyhow::anyhow!("Failed to reshape RGB image: {}", e))
             }
+            ImreadFlags::ImreadUnchanged => dynamic_image_to_ndarray(img),
+        }
+    }
+
+    fn dynamic_image_to_ndarray(img: DynamicImage) -> Result<Array3<u8>> {
+        match img.color().channel_count() {
+            1 => {
+                let gray_img = img.to_luma8();
+                let (width, height) = gray_img.dimensions();
+                Array3::from_shape_vec((height as usize, width as usize, 1), gray_img.into_raw())
+                    .map_err(|e| anyhow::anyhow!("Failed to reshape grayscale image: {}", e))
+            }
+            2 => {
+                let gray_alpha_img = img.to_luma_alpha8();
+                let (width, height) = gray_alpha_img.dimensions();
+                Array3::from_shape_vec(
+                    (height as usize, width as usize, 2),
+                    gray_alpha_img.into_raw(),
+                )
+                .map_err(|e| anyhow::anyhow!("Failed to reshape grayscale+alpha image: {}", e))
+            }
+            3 => {
+                let rgb_img = img.to_rgb8();
+                let (width, height) = rgb_img.dimensions();
+                Array3::from_shape_vec((height as usize, width as usize, 3), rgb_img.into_raw())
+                    .map_err(|e| anyhow::anyhow!("Failed to reshape RGB image: {}", e))
+            }
+            4 => {
+                let rgba_img = img.to_rgba8();
+                let (width, height) = rgba_img.dimensions();
+                Array3::from_shape_vec((height as usize, width as usize, 4), rgba_img.into_raw())
+                    .map_err(|e| anyhow::anyhow!("Failed to reshape RGBA image: {}", e))
+            }
+            channels => anyhow::bail!("Unsupported decoded image channel count: {}", channels),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -330,6 +330,59 @@ mod edge_case_tests {
     }
 }
 
+#[cfg(test)]
+mod cv_compat_tests {
+    use crate::cv_compat::{imdecode, ImreadFlags};
+    use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb, Rgba};
+    use std::io::Cursor;
+
+    #[test]
+    fn test_imdecode_detects_jpeg_without_png_hint() {
+        let mut encoded = Cursor::new(Vec::new());
+        let rgb = ImageBuffer::from_fn(3, 2, |x, y| Rgb([(x * 40) as u8, (y * 80) as u8, 200]));
+
+        DynamicImage::ImageRgb8(rgb)
+            .write_to(&mut encoded, ImageFormat::Jpeg)
+            .unwrap();
+
+        let decoded = imdecode(encoded.get_ref(), ImreadFlags::ImreadColor).unwrap();
+        assert_eq!(decoded.dim(), (2, 3, 3));
+    }
+
+    #[test]
+    fn test_imdecode_detects_webp_without_png_hint() {
+        let mut encoded = Cursor::new(Vec::new());
+        let rgb = ImageBuffer::from_fn(4, 3, |x, y| Rgb([(x * 20) as u8, 100, (y * 30) as u8]));
+
+        DynamicImage::ImageRgb8(rgb)
+            .write_to(&mut encoded, ImageFormat::WebP)
+            .unwrap();
+
+        let decoded = imdecode(encoded.get_ref(), ImreadFlags::ImreadColor).unwrap();
+        assert_eq!(decoded.dim(), (3, 4, 3));
+    }
+
+    #[test]
+    fn test_imdecode_unchanged_preserves_alpha() {
+        let mut encoded = Cursor::new(Vec::new());
+        let rgba = ImageBuffer::from_fn(2, 2, |x, y| {
+            let alpha = if (x + y) % 2 == 0 { 64 } else { 255 };
+            Rgba([10 + x as u8, 20 + y as u8, 30, alpha])
+        });
+
+        DynamicImage::ImageRgba8(rgba)
+            .write_to(&mut encoded, ImageFormat::Png)
+            .unwrap();
+
+        let decoded = imdecode(encoded.get_ref(), ImreadFlags::ImreadUnchanged).unwrap();
+        assert_eq!(decoded.dim(), (2, 2, 4));
+        assert_eq!(decoded[[0, 0, 3]], 64);
+        assert_eq!(decoded[[0, 1, 3]], 255);
+        assert_eq!(decoded[[1, 0, 3]], 255);
+        assert_eq!(decoded[[1, 1, 3]], 64);
+    }
+}
+
 // OpenCV specific tests
 #[cfg(test)]
 mod opencv_tests {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -333,7 +333,7 @@ mod edge_case_tests {
 #[cfg(test)]
 mod cv_compat_tests {
     use crate::cv_compat::{imdecode, ImreadFlags};
-    use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb, Rgba};
+    use image::{DynamicImage, ImageBuffer, ImageFormat, Luma, LumaA, Rgb, Rgba};
     use std::io::Cursor;
 
     #[test]
@@ -380,6 +380,45 @@ mod cv_compat_tests {
         assert_eq!(decoded[[0, 1, 3]], 255);
         assert_eq!(decoded[[1, 0, 3]], 255);
         assert_eq!(decoded[[1, 1, 3]], 64);
+    }
+
+    #[test]
+    fn test_imdecode_grayscale_returns_compat_rgb_shape() {
+        let mut encoded = Cursor::new(Vec::new());
+        let gray = ImageBuffer::from_fn(2, 2, |x, y| Luma([10 + (x + y * 2) as u8]));
+
+        DynamicImage::ImageLuma8(gray)
+            .write_to(&mut encoded, ImageFormat::Png)
+            .unwrap();
+
+        let decoded = imdecode(encoded.get_ref(), ImreadFlags::ImreadGrayscale).unwrap();
+        assert_eq!(decoded.dim(), (2, 2, 3));
+        assert_eq!(decoded[[0, 0, 0]], decoded[[0, 0, 1]]);
+        assert_eq!(decoded[[0, 0, 1]], decoded[[0, 0, 2]]);
+        assert_eq!(decoded[[1, 1, 0]], 13);
+    }
+
+    #[test]
+    fn test_imdecode_unchanged_preserves_luma_alpha_channels() {
+        let mut encoded = Cursor::new(Vec::new());
+        let gray_alpha = ImageBuffer::from_fn(2, 2, |x, y| {
+            let luma = 20 + (x + y * 2) as u8;
+            let alpha = if (x + y) % 2 == 0 { 32 } else { 200 };
+            LumaA([luma, alpha])
+        });
+
+        DynamicImage::ImageLumaA8(gray_alpha)
+            .write_to(&mut encoded, ImageFormat::Png)
+            .unwrap();
+
+        let decoded = imdecode(encoded.get_ref(), ImreadFlags::ImreadUnchanged).unwrap();
+        assert_eq!(decoded.dim(), (2, 2, 2));
+        assert_eq!(decoded[[0, 0, 0]], 20);
+        assert_eq!(decoded[[0, 0, 1]], 32);
+        assert_eq!(decoded[[0, 1, 0]], 21);
+        assert_eq!(decoded[[0, 1, 1]], 200);
+        assert_eq!(decoded[[1, 1, 0]], 23);
+        assert_eq!(decoded[[1, 1, 1]], 32);
     }
 }
 


### PR DESCRIPTION
This pull request refactors the OpenCV-compatible image decoding logic in `cv_compat.rs` to simplify the `imdecode` function, improve its robustness for different image formats and channel counts, and adds comprehensive tests to verify correct behavior for JPEG, WebP, and alpha channel preservation. The main improvements focus on using more robust image decoding APIs, removing manual pixel copying, and ensuring the output array shapes match expectations.

**Image decoding improvements:**

* Refactored `imdecode` to use `image::load_from_memory` instead of manually hinting the format as PNG, allowing automatic detection of various image formats and reducing the risk of decoding errors.
* Replaced manual pixel copying and reshaping logic with direct conversion from image buffers to `ndarray::Array3` using `.into_raw()` and `from_shape_vec`, streamlining the code and reducing potential for bugs.
* Added a helper function `dynamic_image_to_ndarray` to handle images with different channel counts (1, 2, 3, or 4), ensuring correct handling of grayscale, grayscale+alpha, RGB, and RGBA images.

**Testing enhancements:**

* Added a new test module for `cv_compat` that includes tests to verify that `imdecode` correctly detects JPEG and WebP formats without relying on file extension hints, and that the `ImreadUnchanged` flag preserves all image channels including alpha.

**Code cleanup:**

* Removed unused imports (`ImageFormat`, `Cursor`) and replaced them with only the necessary imports for the new logic.