### PR TITLE
release GIL in Python threads and bump OpenCV to 5.x-compatible branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
         components: rustfmt, clippy
 
     - name: Install cargo-audit
-      run: cargo install cargo-audit
+      run: cargo install cargo-audit --version 0.22.2 --locked
 
     - name: Install pre-commit
       run: pip install pre-commit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ numpy = {version = "0.22", optional = true}
 objc = {version = "0.2", optional = true}
 # OpenCV bindings for performance parity
 # Limit binding generation to the modules this crate actually uses.
-opencv = {version = "0.98", optional = true, default-features = false, features = ["clang-runtime", "imgproc", "videoio"]}
+opencv = {version = "0.99", optional = true, default-features = false, features = ["clang-runtime", "imgproc", "videoio"]}
 # Python bindings (optional)
 pyo3 = {version = "0.22", features = ["extension-module"], optional = true}
 rayon = "1.8"

--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -1220,7 +1220,10 @@ pub fn imdecode_py<'py>(
         }
     };
 
-    match imdecode(buf, imread_flags) {
+    let buf = buf.to_vec();
+    let decoded = py.allow_threads(move || imdecode(&buf, imread_flags));
+
+    match decoded {
         Ok(image) => {
             let py_array = PyArray3::from_owned_array_bound(py, image);
             Ok(py_array)


### PR DESCRIPTION
This pull request updates the OpenCV dependency and improves thread safety in the Python bindings. The most important changes are:

**Dependency Updates:**
* Updated the `opencv` crate version from `0.98` to `0.99` in `Cargo.toml` for improved compatibility and access to the latest features and fixes.

**Python Bindings / Thread Safety:**
* Improved the `imdecode_py` function in `src/python_bindings.rs` by moving the image decoding operation into a thread-safe context using `py.allow_threads`, which can help avoid blocking the Python interpreter during decoding.