### PR TITLE
Transfer resize iterator buffers without cloning

### DIFF
--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -599,10 +599,8 @@ fn is_tuple_or_list_of_two(obj: &Bound<PyAny>) -> bool {
 #[cfg(feature = "opencv")]
 #[pyclass]
 pub struct ResizeIterator {
-    /// Raw buffer pointers and their dimensions
-    buffers: Vec<(Vec<u8>, (usize, usize, usize))>, // (buffer, (height, width, channels))
-    /// Current iteration index
-    index: usize,
+    /// Completed buffers waiting to be transferred to NumPy.
+    buffers: std::collections::VecDeque<(Vec<u8>, (usize, usize, usize))>,
 }
 
 #[cfg(feature = "opencv")]
@@ -613,15 +611,11 @@ impl ResizeIterator {
     }
 
     fn __next__<'py>(&mut self, py: Python<'py>) -> Option<Bound<'py, PyArray3<u8>>> {
-        if self.index >= self.buffers.len() {
-            return None;
-        }
+        let (buffer, (height, width, channels)) = self.buffers.pop_front()?;
 
-        let (buffer, (height, width, channels)) = &self.buffers[self.index];
-        self.index += 1;
-
-        // Convert raw buffer directly to PyArray3 - ZERO intermediate steps!
-        match ndarray::Array3::from_shape_vec((*height, *width, *channels), buffer.clone()) {
+        // Transfer the completed allocation directly into the ndarray instead
+        // of cloning the full resized image during iteration.
+        match ndarray::Array3::from_shape_vec((height, width, channels), buffer) {
             Ok(array) => Some(PyArray3::from_owned_array_bound(py, array)),
             Err(_) => None, // Skip malformed arrays
         }
@@ -677,8 +671,7 @@ pub fn batch_resize_images_iterator<'py>(
         return Bound::new(
             py,
             ResizeIterator {
-                buffers: Vec::new(),
-                index: 0,
+                buffers: std::collections::VecDeque::new(),
             },
         );
     }
@@ -856,7 +849,12 @@ pub fn batch_resize_images_iterator<'py>(
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Resize failed: {}", e)))?;
 
     // Return iterator with raw buffers - conversion happens on-demand!
-    Bound::new(py, ResizeIterator { buffers, index: 0 })
+    Bound::new(
+        py,
+        ResizeIterator {
+            buffers: buffers.into(),
+        },
+    )
 }
 
 // TSR CROPPING OPERATIONS (BENCHMARK WINNERS)

--- a/src/python_bindings.rs
+++ b/src/python_bindings.rs
@@ -617,7 +617,7 @@ impl ResizeIterator {
         // of cloning the full resized image during iteration.
         match ndarray::Array3::from_shape_vec((height, width, channels), buffer) {
             Ok(array) => Some(PyArray3::from_owned_array_bound(py, array)),
-            Err(_) => None, // Skip malformed arrays
+            Err(_) => None, // Malformed buffer; end iteration (StopIteration)
         }
     }
 

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -156,6 +156,31 @@ class TestZeroCopyBindings:
         with pytest.raises(ValueError, match="C-contiguous"):
             tsr.batch_resize_images_iterator([strided], [(16, 16)])
 
+    def test_zero_copy_resize_iterator_transfers_each_result(self):
+        """Iterator should yield owned results once and report remaining length."""
+        if not hasattr(tsr, "batch_resize_images_iterator"):
+            pytest.skip("OpenCV resize iterator bindings not available")
+
+        images = [
+            np.full((32, 48, 3), 17, dtype=np.uint8),
+            np.full((24, 40, 3), 231, dtype=np.uint8),
+        ]
+        iterator = tsr.batch_resize_images_iterator(images, [(12, 8), (10, 6)])
+
+        assert len(iterator) == 2
+        first = next(iterator)
+        assert first.shape == (8, 12, 3)
+        assert np.all(first == 17)
+        assert len(iterator) == 1
+
+        second = next(iterator)
+        assert second.shape == (6, 10, 3)
+        assert np.all(second == 231)
+        assert len(iterator) == 0
+
+        with pytest.raises(StopIteration):
+            next(iterator)
+
 
 class TestErrorHandling:
     """Test error handling and edge cases."""


### PR DESCRIPTION
## Summary
- move each completed resize buffer directly into its NumPy ndarray
- replace indexed storage with a queue so iteration can transfer ownership in O(1)
- make `len(iterator)` report the number of remaining results
- add coverage for values, shapes, exhaustion, and remaining length

## Root cause
`ResizeIterator.__next__` cloned the full `Vec<u8>` before constructing every ndarray. The API was described as zero-copy, but consuming it performed one avoidable full-output memory copy per image.

## Performance
Median end-to-end iterator consumption on Apple M3 Max:
- 16 images, 1024x1024 -> 512x512: 2.831 ms -> 1.749 ms (38% faster)
- 64 images, 512x512 -> 224x224: 2.342 ms -> 1.646 ms (30% faster)

## Validation
- added iterator ownership/length/exhaustion regression coverage
- `cargo test --features opencv,simd` (60 passed)
- Python test suite (69 passed)
- repository pre-commit hooks, including competitive performance benchmarks